### PR TITLE
Add adjustable opengl texture buffer size

### DIFF
--- a/src/gui/opengl/qopengltexturecache.cpp
+++ b/src/gui/opengl/qopengltexturecache.cpp
@@ -99,7 +99,7 @@ void QOpenGLTextureCacheWrapper::cleanupTexturesForPixmapData(QPlatformPixmap *p
 
 QOpenGLTextureCache::QOpenGLTextureCache(QOpenGLContext *ctx)
     : QOpenGLSharedResource(ctx->shareGroup())
-    , m_cache(256 * 1024) // 256 MB cache
+    , m_cache(QT_OPENGL_TEXTURE_BUFFER_SIZE * 1024) // QT_OPENGL_TEXTURE_BUFFER_SIZE MB cache
 {
 }
 


### PR DESCRIPTION
With this, you can set max texture buffer size for painting using OpenGL, specifing value of flag QT_OPENGL_TEXTURE_BUFFER_SIZE in megabytes